### PR TITLE
Add Accio support & Update to Swift 5 & Xcode 10.2

### DIFF
--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,1 +1,1 @@
-github "SwiftyBeaver/SwiftyBeaver" "v0.3.0"
+github "SwiftyBeaver/SwiftyBeaver" "1.7.0"

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,20 @@
+// swift-tools-version:4.2
+import PackageDescription
+
+let package = Package(
+    name: "SBObjectiveCWrapper",
+    // platforms: [.iOS("9.0"), .macOS("10.11"), tvOS("9.0"), .watchOS("2.0")],
+    products: [
+        .library(name: "SBObjectiveCWrapper", targets: ["SBObjectiveCWrapper"])
+    ],
+    dependencies: [
+        .package(url: "https://github.com/SwiftyBeaver/SwiftyBeaver.git", .upToNextMajor(from: "1.6.1")),
+    ],
+    targets: [
+        .target(
+            name: "SBObjectiveCWrapper",
+            dependencies: ["SwiftyBeaver"],
+            path: "Sources"
+        )
+    ]
+)

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 ![Platform](https://img.shields.io/badge/Platform-tvOS%209%2B-blue.svg)
 ![Platform](https://img.shields.io/badge/Platform-watchOS%202%2B-blue.svg)
 <br/>
-[![Language Swift 2.3](https://img.shields.io/badge/Language-Swift%202-orange.svg)](https://developer.apple.com/swift)
+[![Language Swift 4.0](https://img.shields.io/badge/Language-Swift%204.0-orange.svg)](https://developer.apple.com/swift)
 [![Carthage compatible](https://img.shields.io/badge/Carthage-compatible-brightgreen.svg)](https://github.com/Carthage/Carthage)
 [![Accio supported](https://img.shields.io/badge/Accio-supported-0A7CF5.svg?style=flat)](https://github.com/JamitLabs/Accio)
 [![Cocoapods compatible](https://img.shields.io/cocoapods/v/SBObjectiveCWrapper.svg)]("https://cocoapods.org)
@@ -15,7 +15,7 @@ SBObjectiveCWrapper enables you to use [SwiftyBeaver](https://github.com/SwiftyB
 ## Requirements
 
 - iOS 9.0+ / Mac OS X 10.9+
-- Xcode 8
+- Xcode 9+
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 <br/>
 [![Language Swift 2.3](https://img.shields.io/badge/Language-Swift%202-orange.svg)](https://developer.apple.com/swift)
 [![Carthage compatible](https://img.shields.io/badge/Carthage-compatible-brightgreen.svg)](https://github.com/Carthage/Carthage)
+[![Accio supported](https://img.shields.io/badge/Accio-supported-0A7CF5.svg?style=flat)](https://github.com/JamitLabs/Accio)
 [![Cocoapods compatible](https://img.shields.io/cocoapods/v/SBObjectiveCWrapper.svg)]("https://cocoapods.org)
 
 SBObjectiveCWrapper enables you to use [SwiftyBeaver](https://github.com/SwiftyBeaver/SwiftyBeaver) logging in your Objective-C code.

--- a/SBObjectiveCWrapper.podspec
+++ b/SBObjectiveCWrapper.podspec
@@ -16,5 +16,5 @@ Pod::Spec.new do |s|
     s.osx.deployment_target = "10.11"
     s.source       = { :git => "https://github.com/SwiftyBeaver/SBObjectiveCWrapper.git", :tag => s.version.to_s }
     s.source_files  = "sources"
-    s.dependency 'SwiftyBeaver', '~> 1.6.1'
+    s.dependency 'SwiftyBeaver', '~> 1.7.0'
 end

--- a/SBObjectiveCWrapper.xcodeproj/project.pbxproj
+++ b/SBObjectiveCWrapper.xcodeproj/project.pbxproj
@@ -25,11 +25,11 @@
 		38A134D71C290FFA00E1B4A9 /* SBObjectiveCWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38A1349A1C28F71700E1B4A9 /* SBObjectiveCWrapper.swift */; };
 		38A134D91C291E4A00E1B4A9 /* TestLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38A134D81C291E4A00E1B4A9 /* TestLogger.swift */; };
 		38A134DC1C291F2A00E1B4A9 /* SBObjectiveCMacroTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 38A134DB1C291F2A00E1B4A9 /* SBObjectiveCMacroTests.m */; };
-		38BED56A1D90499B0067980A /* SwiftyBeaver.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 38BED5691D90499B0067980A /* SwiftyBeaver.framework */; };
-		38BED56C1D9049B40067980A /* SwiftyBeaver.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 38BED56B1D9049B40067980A /* SwiftyBeaver.framework */; };
-		38BED56E1D9049B80067980A /* SwiftyBeaver.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 38BED56D1D9049B80067980A /* SwiftyBeaver.framework */; };
-		38BED5701D9049C40067980A /* SwiftyBeaver.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 38BED56F1D9049C40067980A /* SwiftyBeaver.framework */; };
 		38BED5731D904BFF0067980A /* SBObjectiveCWrapper.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 38A1347B1C28F22900E1B4A9 /* SBObjectiveCWrapper.framework */; };
+		82B22DFA2254E88A004B7905 /* SwiftyBeaver.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 82B22DF92254E884004B7905 /* SwiftyBeaver.framework */; };
+		82B22DFB2254E88E004B7905 /* SwiftyBeaver.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 82B22DF82254E884004B7905 /* SwiftyBeaver.framework */; };
+		82B22DFC2254E894004B7905 /* SwiftyBeaver.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 82B22DF72254E884004B7905 /* SwiftyBeaver.framework */; };
+		82B22DFD2254E898004B7905 /* SwiftyBeaver.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 82B22DF62254E884004B7905 /* SwiftyBeaver.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -72,10 +72,10 @@
 		38A134D81C291E4A00E1B4A9 /* TestLogger.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestLogger.swift; sourceTree = "<group>"; };
 		38A134DA1C291F2A00E1B4A9 /* SBObjectiveCWrapperTests-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "SBObjectiveCWrapperTests-Bridging-Header.h"; path = "Supporting Files/SBObjectiveCWrapperTests-Bridging-Header.h"; sourceTree = "<group>"; };
 		38A134DB1C291F2A00E1B4A9 /* SBObjectiveCMacroTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SBObjectiveCMacroTests.m; sourceTree = "<group>"; };
-		38BED5691D90499B0067980A /* SwiftyBeaver.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SwiftyBeaver.framework; path = "../../../../Library/Developer/Xcode/DerivedData/SBObjectiveCWrapper-ayduudlbdbtpwzgbklgvavovmarh/Build/Products/Debug-iphonesimulator/SwiftyBeaver.framework"; sourceTree = "<group>"; };
-		38BED56B1D9049B40067980A /* SwiftyBeaver.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SwiftyBeaver.framework; path = "lib/SwiftyBeaver/build/Debug-watchos/SwiftyBeaver.framework"; sourceTree = "<group>"; };
-		38BED56D1D9049B80067980A /* SwiftyBeaver.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SwiftyBeaver.framework; path = "lib/SwiftyBeaver/build/Debug-appletvos/SwiftyBeaver.framework"; sourceTree = "<group>"; };
-		38BED56F1D9049C40067980A /* SwiftyBeaver.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SwiftyBeaver.framework; path = lib/SwiftyBeaver/build/Debug/SwiftyBeaver.framework; sourceTree = "<group>"; };
+		82B22DF62254E884004B7905 /* SwiftyBeaver.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SwiftyBeaver.framework; path = Carthage/Build/tvOS/SwiftyBeaver.framework; sourceTree = "<group>"; };
+		82B22DF72254E884004B7905 /* SwiftyBeaver.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SwiftyBeaver.framework; path = Carthage/Build/Mac/SwiftyBeaver.framework; sourceTree = "<group>"; };
+		82B22DF82254E884004B7905 /* SwiftyBeaver.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SwiftyBeaver.framework; path = Carthage/Build/watchOS/SwiftyBeaver.framework; sourceTree = "<group>"; };
+		82B22DF92254E884004B7905 /* SwiftyBeaver.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SwiftyBeaver.framework; path = Carthage/Build/iOS/SwiftyBeaver.framework; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -91,7 +91,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				38BED56A1D90499B0067980A /* SwiftyBeaver.framework in Frameworks */,
+				82B22DFA2254E88A004B7905 /* SwiftyBeaver.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -107,7 +107,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				38BED56C1D9049B40067980A /* SwiftyBeaver.framework in Frameworks */,
+				82B22DFB2254E88E004B7905 /* SwiftyBeaver.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -115,7 +115,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				38BED56E1D9049B80067980A /* SwiftyBeaver.framework in Frameworks */,
+				82B22DFD2254E898004B7905 /* SwiftyBeaver.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -123,7 +123,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				38BED5701D9049C40067980A /* SwiftyBeaver.framework in Frameworks */,
+				82B22DFC2254E894004B7905 /* SwiftyBeaver.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -233,10 +233,10 @@
 		38BED5681D90499B0067980A /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				38BED56F1D9049C40067980A /* SwiftyBeaver.framework */,
-				38BED56D1D9049B80067980A /* SwiftyBeaver.framework */,
-				38BED56B1D9049B40067980A /* SwiftyBeaver.framework */,
-				38BED5691D90499B0067980A /* SwiftyBeaver.framework */,
+				82B22DF92254E884004B7905 /* SwiftyBeaver.framework */,
+				82B22DF82254E884004B7905 /* SwiftyBeaver.framework */,
+				82B22DF72254E884004B7905 /* SwiftyBeaver.framework */,
+				82B22DF62254E884004B7905 /* SwiftyBeaver.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -423,6 +423,7 @@
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				English,
 				en,
 				Base,
 			);
@@ -585,7 +586,6 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Example-iOS/Example-iOS-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
@@ -601,7 +601,6 @@
 				PRODUCT_MODULE_NAME = Example_iOS;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Example-iOS/Example-iOS-Bridging-Header.h";
-				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};
@@ -651,7 +650,7 @@
 				PRODUCT_NAME = "";
 				SDKROOT = iphoneos;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 4.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
@@ -697,7 +696,7 @@
 				PRODUCT_NAME = "";
 				SDKROOT = iphoneos;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 4.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALIDATE_PRODUCT = YES;
 				VERSIONING_SYSTEM = "apple-generic";
@@ -716,7 +715,7 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				FRAMEWORK_SEARCH_PATHS = "";
+				FRAMEWORK_SEARCH_PATHS = "$(PROJECT_DIR)/Carthage/Build/iOS";
 				INFOPLIST_FILE = SBObjectiveCWrapper/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
@@ -725,7 +724,6 @@
 				PRODUCT_NAME = SBObjectiveCWrapper;
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
@@ -740,7 +738,7 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				FRAMEWORK_SEARCH_PATHS = "";
+				FRAMEWORK_SEARCH_PATHS = "$(PROJECT_DIR)/Carthage/Build/iOS";
 				INFOPLIST_FILE = SBObjectiveCWrapper/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
@@ -748,7 +746,6 @@
 				PRODUCT_MODULE_NAME = SBObjectiveCWrapper;
 				PRODUCT_NAME = SBObjectiveCWrapper;
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};
@@ -763,7 +760,6 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "SBObjectiveCWrapperTests/Supporting Files/SBObjectiveCWrapperTests-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
@@ -777,7 +773,6 @@
 				PRODUCT_MODULE_NAME = SBObjectiveCWrapperTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "SBObjectiveCWrapperTests/Supporting Files/SBObjectiveCWrapperTests-Bridging-Header.h";
-				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};
@@ -790,7 +785,10 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				FRAMEWORK_SEARCH_PATHS = "$(PROJECT_DIR)/lib/SwiftyBeaver/build/Debug-watchos";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(PROJECT_DIR)/lib/SwiftyBeaver/build/Debug-watchos",
+					"$(PROJECT_DIR)/Carthage/Build/watchOS",
+				);
 				INFOPLIST_FILE = SBObjectiveCWrapper/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
@@ -799,7 +797,6 @@
 				PRODUCT_NAME = SBObjectiveCWrapper;
 				SDKROOT = watchos;
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 3.0;
 				TARGETED_DEVICE_FAMILY = 4;
 				WATCHOS_DEPLOYMENT_TARGET = 3.0;
 			};
@@ -814,7 +811,10 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				FRAMEWORK_SEARCH_PATHS = "$(PROJECT_DIR)/lib/SwiftyBeaver/build/Debug-watchos";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(PROJECT_DIR)/lib/SwiftyBeaver/build/Debug-watchos",
+					"$(PROJECT_DIR)/Carthage/Build/watchOS",
+				);
 				INFOPLIST_FILE = SBObjectiveCWrapper/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
@@ -823,7 +823,6 @@
 				PRODUCT_NAME = SBObjectiveCWrapper;
 				SDKROOT = watchos;
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 3.0;
 				TARGETED_DEVICE_FAMILY = 4;
 				WATCHOS_DEPLOYMENT_TARGET = 3.0;
 			};
@@ -838,7 +837,10 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				FRAMEWORK_SEARCH_PATHS = "$(PROJECT_DIR)/lib/SwiftyBeaver/build/Debug-appletvos";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(PROJECT_DIR)/lib/SwiftyBeaver/build/Debug-appletvos",
+					"$(PROJECT_DIR)/Carthage/Build/tvOS",
+				);
 				INFOPLIST_FILE = SBObjectiveCWrapper/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
@@ -847,7 +849,6 @@
 				PRODUCT_NAME = SBObjectiveCWrapper;
 				SDKROOT = appletvos;
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 3.0;
 				TARGETED_DEVICE_FAMILY = 3;
 				TVOS_DEPLOYMENT_TARGET = 9.1;
 			};
@@ -862,7 +863,10 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				FRAMEWORK_SEARCH_PATHS = "$(PROJECT_DIR)/lib/SwiftyBeaver/build/Debug-appletvos";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(PROJECT_DIR)/lib/SwiftyBeaver/build/Debug-appletvos",
+					"$(PROJECT_DIR)/Carthage/Build/tvOS",
+				);
 				INFOPLIST_FILE = SBObjectiveCWrapper/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
@@ -871,7 +875,6 @@
 				PRODUCT_NAME = SBObjectiveCWrapper;
 				SDKROOT = appletvos;
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 3.0;
 				TARGETED_DEVICE_FAMILY = 3;
 				TVOS_DEPLOYMENT_TARGET = 9.1;
 			};
@@ -887,7 +890,10 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				FRAMEWORK_SEARCH_PATHS = "$(PROJECT_DIR)/lib/SwiftyBeaver/build/Debug";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(PROJECT_DIR)/lib/SwiftyBeaver/build/Debug",
+					"$(PROJECT_DIR)/Carthage/Build/Mac",
+				);
 				FRAMEWORK_VERSION = A;
 				INFOPLIST_FILE = SBObjectiveCWrapper/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
@@ -898,7 +904,6 @@
 				PRODUCT_NAME = SBObjectiveCWrapper;
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
@@ -912,7 +917,10 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				FRAMEWORK_SEARCH_PATHS = "$(PROJECT_DIR)/lib/SwiftyBeaver/build/Debug";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(PROJECT_DIR)/lib/SwiftyBeaver/build/Debug",
+					"$(PROJECT_DIR)/Carthage/Build/Mac",
+				);
 				FRAMEWORK_VERSION = A;
 				INFOPLIST_FILE = SBObjectiveCWrapper/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
@@ -923,7 +931,6 @@
 				PRODUCT_NAME = SBObjectiveCWrapper;
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};

--- a/SBObjectiveCWrapper.xcodeproj/project.pbxproj
+++ b/SBObjectiveCWrapper.xcodeproj/project.pbxproj
@@ -25,11 +25,11 @@
 		38A134D71C290FFA00E1B4A9 /* SBObjectiveCWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38A1349A1C28F71700E1B4A9 /* SBObjectiveCWrapper.swift */; };
 		38A134D91C291E4A00E1B4A9 /* TestLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38A134D81C291E4A00E1B4A9 /* TestLogger.swift */; };
 		38A134DC1C291F2A00E1B4A9 /* SBObjectiveCMacroTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 38A134DB1C291F2A00E1B4A9 /* SBObjectiveCMacroTests.m */; };
+		38BED56A1D90499B0067980A /* SwiftyBeaver.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 38BED5691D90499B0067980A /* SwiftyBeaver.framework */; };
+		38BED56C1D9049B40067980A /* SwiftyBeaver.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 38BED56B1D9049B40067980A /* SwiftyBeaver.framework */; };
+		38BED56E1D9049B80067980A /* SwiftyBeaver.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 38BED56D1D9049B80067980A /* SwiftyBeaver.framework */; };
+		38BED5701D9049C40067980A /* SwiftyBeaver.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 38BED56F1D9049C40067980A /* SwiftyBeaver.framework */; };
 		38BED5731D904BFF0067980A /* SBObjectiveCWrapper.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 38A1347B1C28F22900E1B4A9 /* SBObjectiveCWrapper.framework */; };
-		82B22DFA2254E88A004B7905 /* SwiftyBeaver.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 82B22DF92254E884004B7905 /* SwiftyBeaver.framework */; };
-		82B22DFB2254E88E004B7905 /* SwiftyBeaver.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 82B22DF82254E884004B7905 /* SwiftyBeaver.framework */; };
-		82B22DFC2254E894004B7905 /* SwiftyBeaver.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 82B22DF72254E884004B7905 /* SwiftyBeaver.framework */; };
-		82B22DFD2254E898004B7905 /* SwiftyBeaver.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 82B22DF62254E884004B7905 /* SwiftyBeaver.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -72,10 +72,10 @@
 		38A134D81C291E4A00E1B4A9 /* TestLogger.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestLogger.swift; sourceTree = "<group>"; };
 		38A134DA1C291F2A00E1B4A9 /* SBObjectiveCWrapperTests-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "SBObjectiveCWrapperTests-Bridging-Header.h"; path = "Supporting Files/SBObjectiveCWrapperTests-Bridging-Header.h"; sourceTree = "<group>"; };
 		38A134DB1C291F2A00E1B4A9 /* SBObjectiveCMacroTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SBObjectiveCMacroTests.m; sourceTree = "<group>"; };
-		82B22DF62254E884004B7905 /* SwiftyBeaver.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SwiftyBeaver.framework; path = Carthage/Build/tvOS/SwiftyBeaver.framework; sourceTree = "<group>"; };
-		82B22DF72254E884004B7905 /* SwiftyBeaver.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SwiftyBeaver.framework; path = Carthage/Build/Mac/SwiftyBeaver.framework; sourceTree = "<group>"; };
-		82B22DF82254E884004B7905 /* SwiftyBeaver.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SwiftyBeaver.framework; path = Carthage/Build/watchOS/SwiftyBeaver.framework; sourceTree = "<group>"; };
-		82B22DF92254E884004B7905 /* SwiftyBeaver.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SwiftyBeaver.framework; path = Carthage/Build/iOS/SwiftyBeaver.framework; sourceTree = "<group>"; };
+		38BED5691D90499B0067980A /* SwiftyBeaver.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SwiftyBeaver.framework; path = "../../../../Library/Developer/Xcode/DerivedData/SBObjectiveCWrapper-ayduudlbdbtpwzgbklgvavovmarh/Build/Products/Debug-iphonesimulator/SwiftyBeaver.framework"; sourceTree = "<group>"; };
+		38BED56B1D9049B40067980A /* SwiftyBeaver.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SwiftyBeaver.framework; path = "lib/SwiftyBeaver/build/Debug-watchos/SwiftyBeaver.framework"; sourceTree = "<group>"; };
+		38BED56D1D9049B80067980A /* SwiftyBeaver.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SwiftyBeaver.framework; path = "lib/SwiftyBeaver/build/Debug-appletvos/SwiftyBeaver.framework"; sourceTree = "<group>"; };
+		38BED56F1D9049C40067980A /* SwiftyBeaver.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SwiftyBeaver.framework; path = lib/SwiftyBeaver/build/Debug/SwiftyBeaver.framework; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -91,7 +91,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				82B22DFA2254E88A004B7905 /* SwiftyBeaver.framework in Frameworks */,
+				38BED56A1D90499B0067980A /* SwiftyBeaver.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -107,7 +107,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				82B22DFB2254E88E004B7905 /* SwiftyBeaver.framework in Frameworks */,
+				38BED56C1D9049B40067980A /* SwiftyBeaver.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -115,7 +115,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				82B22DFD2254E898004B7905 /* SwiftyBeaver.framework in Frameworks */,
+				38BED56E1D9049B80067980A /* SwiftyBeaver.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -123,7 +123,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				82B22DFC2254E894004B7905 /* SwiftyBeaver.framework in Frameworks */,
+				38BED5701D9049C40067980A /* SwiftyBeaver.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -233,10 +233,10 @@
 		38BED5681D90499B0067980A /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				82B22DF92254E884004B7905 /* SwiftyBeaver.framework */,
-				82B22DF82254E884004B7905 /* SwiftyBeaver.framework */,
-				82B22DF72254E884004B7905 /* SwiftyBeaver.framework */,
-				82B22DF62254E884004B7905 /* SwiftyBeaver.framework */,
+				38BED56F1D9049C40067980A /* SwiftyBeaver.framework */,
+				38BED56D1D9049B80067980A /* SwiftyBeaver.framework */,
+				38BED56B1D9049B40067980A /* SwiftyBeaver.framework */,
+				38BED5691D90499B0067980A /* SwiftyBeaver.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -715,7 +715,7 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				FRAMEWORK_SEARCH_PATHS = "$(PROJECT_DIR)/Carthage/Build/iOS";
+				FRAMEWORK_SEARCH_PATHS = "";
 				INFOPLIST_FILE = SBObjectiveCWrapper/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
@@ -738,7 +738,7 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				FRAMEWORK_SEARCH_PATHS = "$(PROJECT_DIR)/Carthage/Build/iOS";
+				FRAMEWORK_SEARCH_PATHS = "";
 				INFOPLIST_FILE = SBObjectiveCWrapper/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
@@ -785,10 +785,7 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(PROJECT_DIR)/lib/SwiftyBeaver/build/Debug-watchos",
-					"$(PROJECT_DIR)/Carthage/Build/watchOS",
-				);
+				FRAMEWORK_SEARCH_PATHS = "$(PROJECT_DIR)/lib/SwiftyBeaver/build/Debug-watchos";
 				INFOPLIST_FILE = SBObjectiveCWrapper/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
@@ -811,10 +808,7 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(PROJECT_DIR)/lib/SwiftyBeaver/build/Debug-watchos",
-					"$(PROJECT_DIR)/Carthage/Build/watchOS",
-				);
+				FRAMEWORK_SEARCH_PATHS = "$(PROJECT_DIR)/lib/SwiftyBeaver/build/Debug-watchos";
 				INFOPLIST_FILE = SBObjectiveCWrapper/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
@@ -837,10 +831,7 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(PROJECT_DIR)/lib/SwiftyBeaver/build/Debug-appletvos",
-					"$(PROJECT_DIR)/Carthage/Build/tvOS",
-				);
+				FRAMEWORK_SEARCH_PATHS = "$(PROJECT_DIR)/lib/SwiftyBeaver/build/Debug-appletvos";
 				INFOPLIST_FILE = SBObjectiveCWrapper/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
@@ -863,10 +854,7 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(PROJECT_DIR)/lib/SwiftyBeaver/build/Debug-appletvos",
-					"$(PROJECT_DIR)/Carthage/Build/tvOS",
-				);
+				FRAMEWORK_SEARCH_PATHS = "$(PROJECT_DIR)/lib/SwiftyBeaver/build/Debug-appletvos";
 				INFOPLIST_FILE = SBObjectiveCWrapper/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
@@ -890,10 +878,7 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(PROJECT_DIR)/lib/SwiftyBeaver/build/Debug",
-					"$(PROJECT_DIR)/Carthage/Build/Mac",
-				);
+				FRAMEWORK_SEARCH_PATHS = "$(PROJECT_DIR)/lib/SwiftyBeaver/build/Debug";
 				FRAMEWORK_VERSION = A;
 				INFOPLIST_FILE = SBObjectiveCWrapper/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
@@ -917,10 +902,7 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(PROJECT_DIR)/lib/SwiftyBeaver/build/Debug",
-					"$(PROJECT_DIR)/Carthage/Build/Mac",
-				);
+				FRAMEWORK_SEARCH_PATHS = "$(PROJECT_DIR)/lib/SwiftyBeaver/build/Debug";
 				FRAMEWORK_VERSION = A;
 				INFOPLIST_FILE = SBObjectiveCWrapper/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";

--- a/SBObjectiveCWrapper.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/SBObjectiveCWrapper.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>


### PR DESCRIPTION
This adds support for SwiftPM manifest based dependency managers. Specifically this adds support for installing via [Accio](https://github.com/JamitLabs/Accio) but will probably also work with SwiftPM once it's integrated into Xcode.

This also fixes #13 and updates SwiftyBeaver to version 1.7.0.